### PR TITLE
Dev

### DIFF
--- a/main.go
+++ b/main.go
@@ -330,7 +330,9 @@ func processBlockquote(node *html.Node) string {
 	newline := ""
 	for el := node.FirstChild; el != nil; el = el.NextSibling {
 		if el.Type == html.TextNode {
-			text += fmt.Sprintf("%v%v", newline, strings.TrimSpace(el.Data))
+			// UnescapeString для el.Data нужен, чтобы избавляться от &quot; в цитатах
+			// для последущего корректного чтения в exel, кстати гугл таблицы корректно обрабатывали эти циттаты и не ломали csv
+			text += fmt.Sprintf("%v%v", newline, strings.TrimSpace(html.UnescapeString(el.Data)))
 			newline = fmt.Sprintf("\n%v", "")
 		}
 		if el.Type == html.ElementNode && nodeHasRequiredCssClass("author", el) {
@@ -396,7 +398,7 @@ func writeCSVFile(topic Topic, outputPath string) {
 		topic.Question.Role,
 		topic.Question.Text,
 		topic.Question.Datetime,
-		topic.Question.DataID,
+		//topic.Question.DataID,
 	})
 
 	// Add linked question to output data

--- a/main.go
+++ b/main.go
@@ -331,7 +331,7 @@ func processBlockquote(node *html.Node) string {
 	for el := node.FirstChild; el != nil; el = el.NextSibling {
 		if el.Type == html.TextNode {
 			// UnescapeString для el.Data нужен, чтобы избавляться от &quot; в цитатах
-			// для последущего корректного чтения в exel, кстати гугл таблицы корректно обрабатывали эти циттаты и не ломали csv
+			// для последующего корректного чтения в exel, кстати гугл таблицы корректно обрабатывали эти цитаты и не ломали csv
 			text += fmt.Sprintf("%v%v", newline, strings.TrimSpace(html.UnescapeString(el.Data)))
 			newline = fmt.Sprintf("\n%v", "")
 		}


### PR DESCRIPTION
UnescapeString для el.Data нужен, чтобы избавляться от &quot; в цитатах
для последующего корректного чтения в exel, кстати гугл таблицы корректно обрабатывали эти цитаты и не ломали csv.

При обильном появлении в тексте csv &quot; ломалась структура при попытке прочитать файлы exel или яндекс таблицами

`&quot; Ведь с одной стороны мы его не видим, не ощущаем, приборы оказывается просто безделушки, но с другой стороны нет дыма без огня.&quot;`